### PR TITLE
Allow for per-module overrides of cbguard settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,4 +194,27 @@ moduleSettings = {
 `relocate` refers to calling `relocate` on the controller. The user will be redirected to the new page.
 `override` refers to `event.overrideEvent`. This will not redirect but simply change the running event.
 
-`
+
+### Module Overrides
+
+All of the `cbguard` settings can be overriden inside a module.  This allows modules, such as an API module, to provide
+their own authentication services as well as redirect events.
+
+To specify some overrides, create a `cbguard` struct in your desired module's `settings` in that module's `ModuleConfig.cfc`.
+
+```cfc
+component {
+
+    this.name = "myModule";
+
+    function configure() {
+        settings = {
+            "cbguard" = {
+                "authenticationOverrideEvent" = "myModule:Main.onAuthenticationFailure",
+                "authorizationOverrideEvent" = "myModule:Main.onAuthorizationFailure"
+            }
+        };
+    }
+
+}
+```

--- a/interceptors/SecuredEventInterceptor.cfc
+++ b/interceptors/SecuredEventInterceptor.cfc
@@ -1,7 +1,8 @@
 component extends="coldbox.system.Interceptor"{
 
-    property name="handlerService" inject="coldbox:handlerService";
     property name="coldboxVersion" inject="coldbox:fwSetting:version";
+    property name="handlerService" inject="coldbox:handlerService";
+    property name="moduleService" inject="coldbox:moduleService";
 
     void function configure() {}
 
@@ -16,8 +17,13 @@ component extends="coldbox.system.Interceptor"{
     * the event is overridden to the event specified in module settings.
     */
     function preProcess( event, rc, prc, interceptData, buffer ) {
-        if ( isNull( variables.authenticationService ) ) {
-            variables.authenticationService = wirebox.getInstance( getProperty( "AuthenticationService" ) );
+        var overrides = {};
+        if ( event.getCurrentModule() != "" ) {
+            var moduleConfig = moduleService.getModuleConfigCache()[ event.getCurrentModule() ];
+            var moduleSettings = moduleConfig.getPropertyMixin( "settings", "variables", {} );
+            if ( structKeyExists( moduleSettings, "cbguard" ) ) {
+                overrides = moduleSettings.cbguard;
+            }
         }
 
         if( listFirst( coldboxVersion, "." ) >= 5 ){
@@ -32,8 +38,8 @@ component extends="coldbox.system.Interceptor"{
 
         var handlerMetadata = getMetadata( handler );
 
-        return notAuthorizedForHandler( handlerMetadata, event ) ||
-            notAuthorizedForAction( handlerMetadata, event );
+        return notAuthorizedForHandler( handlerMetadata, event, overrides ) ||
+            notAuthorizedForAction( handlerMetadata, event, overrides );
     }
 
     /**
@@ -45,7 +51,19 @@ component extends="coldbox.system.Interceptor"{
     * If the user is not logged in or does not have one of the required permissions,
     * the event is overridden to the event specified in module settings.
     */
-    private function notAuthorizedForHandler( handlerMetadata, event ) {
+    private function notAuthorizedForHandler( handlerMetadata, event, overrides = {} ) {
+        var props = {};
+        structAppend( props, variables.properties, true );
+        structAppend( props, overrides, true );
+
+        if ( isSimpleValue( props.authenticationService ) ) {
+            props.authenticationService = wirebox.getInstance( props.authenticationService );
+        }
+        param props.authenticationOverrideEvent = "";
+        param props.authenticationAjaxOverrideEvent = props.authenticationOverrideEvent;
+        param props.authorizationOverrideEvent = "";
+        param props.authorizationAjaxOverrideEvent = props.authorizationOverrideEvent;
+
         if ( ! structKeyExists( handlerMetadata, "secured" ) ) {
             return false;
         }
@@ -54,10 +72,10 @@ component extends="coldbox.system.Interceptor"{
             return false;
         }
 
-        if ( ! invoke( authenticationService, getProperty( "methodNames" )[ "isLoggedIn" ] ) ) {
+        if ( ! invoke( props.authenticationService, props.methodNames[ "isLoggedIn" ] ) ) {
             var eventType = event.isAjax() ? "authenticationAjaxOverrideEvent" : "authenticationOverrideEvent";
-            var relocateEvent = getProperty( eventType );
-            var overrideAction = getProperty( "overrideActions" )[ eventType ];
+            var relocateEvent = props.eventType;
+            var overrideAction = props.overrideActions[ eventType ];
             switch ( overrideAction ) {
                 case "relocate":
                     relocate( relocateEvent );
@@ -83,17 +101,17 @@ component extends="coldbox.system.Interceptor"{
             return false;
         }
 
-        var loggedInUser = invoke( authenticationService, getProperty( "methodNames" )[ "getUser" ] );
+        var loggedInUser = invoke( props.authenticationService, props.methodNames[ "getUser" ] );
 
         for ( var permission in neededPermissions ) {
-            if ( invoke( loggedInUser, getProperty( "methodNames" )[ "hasPermission" ], { permission = permission } ) ) {
+            if ( invoke( loggedInUser, props.methodNames[ "hasPermission" ], { permission = permission } ) ) {
                 return false;
             }
         }
 
         var eventType = event.isAjax() ? "authorizationAjaxOverrideEvent" : "authorizationOverrideEvent";
-        var relocateEvent = getProperty( eventType );
-        var overrideAction = getProperty( "overrideActions" )[ eventType ];
+        var relocateEvent = props.eventType;
+        var overrideAction = props.overrideActions[ eventType ];
         switch ( overrideAction ) {
             case "relocate":
                 relocate( relocateEvent );
@@ -119,7 +137,19 @@ component extends="coldbox.system.Interceptor"{
     * If the user is not logged in or does not have one of the required permissions,
     * the event is overridden to the event specified in module settings.
     */
-    private function notAuthorizedForAction( handlerMetadata, event ) {
+    private function notAuthorizedForAction( handlerMetadata, event, overrides = {} ) {
+        var props = {};
+        structAppend( props, variables.properties, true );
+        structAppend( props, overrides, true );
+
+        if ( isSimpleValue( props.authenticationService ) ) {
+            props.authenticationService = wirebox.getInstance( props.authenticationService );
+        }
+        param props.authenticationOverrideEvent = "";
+        param props.authenticationAjaxOverrideEvent = props.authenticationOverrideEvent;
+        param props.authorizationOverrideEvent = "";
+        param props.authorizationAjaxOverrideEvent = props.authorizationOverrideEvent;
+
         if ( ! structKeyExists( handlerMetadata, "functions" ) ) {
             return false;
         }
@@ -137,10 +167,10 @@ component extends="coldbox.system.Interceptor"{
             return false;
         }
 
-        if ( ! invoke( authenticationService, getProperty( "methodNames" )[ "isLoggedIn" ] ) ) {
+        if ( ! invoke( props.authenticationService, props.methodNames[ "isLoggedIn" ] ) ) {
             var eventType = event.isAjax() ? "authenticationAjaxOverrideEvent" : "authenticationOverrideEvent";
-            var relocateEvent = getProperty( eventType );
-            var overrideAction = getProperty( "overrideActions" )[ eventType ];
+            var relocateEvent = props.eventType;
+            var overrideAction = props.overrideActions[ eventType ];
             switch ( overrideAction ) {
                 case "relocate":
                     relocate( relocateEvent );
@@ -166,17 +196,17 @@ component extends="coldbox.system.Interceptor"{
             return false;
         }
 
-        var loggedInUser = invoke( authenticationService, getProperty( "methodNames" )[ "getUser" ] );
+        var loggedInUser = invoke( props.authenticationService, props.methodNames[ "getUser" ] );
 
         for ( var permission in neededPermissions ) {
-            if ( invoke( loggedInUser, getProperty( "methodNames" )[ "hasPermission" ], { permission = permission } ) ) {
+            if ( invoke( loggedInUser, props.methodNames[ "hasPermission" ], { permission = permission } ) ) {
                 return false;
             }
         }
 
         var eventType = event.isAjax() ? "authorizationAjaxOverrideEvent" : "authorizationOverrideEvent";
-        var relocateEvent = getProperty( eventType );
-        var overrideAction = getProperty( "overrideActions" )[ eventType ];
+        var relocateEvent = props.eventType;
+        var overrideAction = props.overrideActions[ eventType ];
         switch ( overrideAction ) {
             case "relocate":
                 relocate( relocateEvent );

--- a/interceptors/SecuredEventInterceptor.cfc
+++ b/interceptors/SecuredEventInterceptor.cfc
@@ -74,7 +74,7 @@ component extends="coldbox.system.Interceptor"{
 
         if ( ! invoke( props.authenticationService, props.methodNames[ "isLoggedIn" ] ) ) {
             var eventType = event.isAjax() ? "authenticationAjaxOverrideEvent" : "authenticationOverrideEvent";
-            var relocateEvent = props.eventType;
+            var relocateEvent = props[ eventType ];
             var overrideAction = props.overrideActions[ eventType ];
             switch ( overrideAction ) {
                 case "relocate":
@@ -110,7 +110,7 @@ component extends="coldbox.system.Interceptor"{
         }
 
         var eventType = event.isAjax() ? "authorizationAjaxOverrideEvent" : "authorizationOverrideEvent";
-        var relocateEvent = props.eventType;
+        var relocateEvent = props[ eventType ];
         var overrideAction = props.overrideActions[ eventType ];
         switch ( overrideAction ) {
             case "relocate":
@@ -169,7 +169,7 @@ component extends="coldbox.system.Interceptor"{
 
         if ( ! invoke( props.authenticationService, props.methodNames[ "isLoggedIn" ] ) ) {
             var eventType = event.isAjax() ? "authenticationAjaxOverrideEvent" : "authenticationOverrideEvent";
-            var relocateEvent = props.eventType;
+            var relocateEvent = props[ eventType ];
             var overrideAction = props.overrideActions[ eventType ];
             switch ( overrideAction ) {
                 case "relocate":
@@ -205,7 +205,7 @@ component extends="coldbox.system.Interceptor"{
         }
 
         var eventType = event.isAjax() ? "authorizationAjaxOverrideEvent" : "authorizationOverrideEvent";
-        var relocateEvent = props.eventType;
+        var relocateEvent = props[ eventType ];
         var overrideAction = props.overrideActions[ eventType ];
         switch ( overrideAction ) {
             case "relocate":

--- a/tests/resources/app/config/Coldbox.cfc
+++ b/tests/resources/app/config/Coldbox.cfc
@@ -26,7 +26,7 @@
 			//Extension Points
 			applicationHelper 			= "includes/helpers/ApplicationHelper.cfm",
 			viewsHelper					= "",
-			modulesExternalLocation		= [ "modules_app" ],
+			modulesExternalLocation		= [ "/app/modules_app" ],
 			viewsExternalLocation		= "",
 			layoutsExternalLocation 	= "",
 			handlersExternalLocation  	= "",

--- a/tests/resources/app/modules_app/myModule/ModuleConfig.cfc
+++ b/tests/resources/app/modules_app/myModule/ModuleConfig.cfc
@@ -1,0 +1,25 @@
+component {
+
+    this.title        = "myModule";
+    this.description  = "myModule";
+    this.version      = "1.0.0";
+    this.cfmapping    = "myModule";
+    this.dependencies = [];
+
+    function configure() {
+        settings = {
+            "cbguard" = {
+                "authenticationService" = "SecurityService@myModule",
+                "authenticationOverrideEvent" = "myModule:Main.onAuthenticationFailure",
+                "authenticationAjaxOverrideEvent" = "myModule:api.v1.BaseAPIHandler.onAuthenticationFailure",
+                "authorizationOverrideEvent" = "myModule:Main.onAuthorizationFailure",
+                "authorizationAjaxOverrideEvent" = "myModule:api.v1.BaseAPIHandler.onAuthorizationFailure"
+            }
+        };
+
+        routes = [
+            { pattern = "/:handler/:action?" }
+        ];
+    }
+
+}

--- a/tests/resources/app/modules_app/myModule/handlers/DoubleSecured.cfc
+++ b/tests/resources/app/modules_app/myModule/handlers/DoubleSecured.cfc
@@ -1,0 +1,7 @@
+component secured="one" {
+
+    function securedAction( event, rc, prc ) secured="two" {
+        event.noRender();
+    }
+
+}

--- a/tests/resources/app/modules_app/myModule/handlers/Main.cfc
+++ b/tests/resources/app/modules_app/myModule/handlers/Main.cfc
@@ -1,0 +1,11 @@
+component {
+
+    function onAuthenticationFailure() {
+        event.noRender();
+    }
+
+    function onAuthorizationFailure() {
+        event.noRender();
+    }
+
+}

--- a/tests/resources/app/modules_app/myModule/handlers/PermissionActionSecured.cfc
+++ b/tests/resources/app/modules_app/myModule/handlers/PermissionActionSecured.cfc
@@ -1,0 +1,7 @@
+component {
+
+    function fooPermissionAction( event, rc, prc ) secured="foo" {
+        event.noRender();
+    }
+
+}

--- a/tests/resources/app/modules_app/myModule/handlers/PermissionSecured.cfc
+++ b/tests/resources/app/modules_app/myModule/handlers/PermissionSecured.cfc
@@ -1,0 +1,7 @@
+component secured="foo" {
+
+    function fooPermissionAction( event, rc, prc ) {
+        event.noRender();
+    }
+
+}

--- a/tests/resources/app/modules_app/myModule/handlers/api/v1/BaseAPIHandler.cfc
+++ b/tests/resources/app/modules_app/myModule/handlers/api/v1/BaseAPIHandler.cfc
@@ -1,0 +1,11 @@
+component {
+
+    function onAuthenticationFailure() {
+        event.noRender();
+    }
+
+    function onAuthorizationFailure() {
+        event.noRender();
+    }
+
+}

--- a/tests/resources/app/modules_app/myModule/models/SecurityService.cfc
+++ b/tests/resources/app/modules_app/myModule/models/SecurityService.cfc
@@ -1,0 +1,29 @@
+component {
+
+    public function getUser() {
+        if ( structKeyExists( request, "user" ) ) {
+            return request.user;
+        }
+        var newUser = wirebox.getInstance( "User" );
+        if ( structKeyExists( session, "userId" ) ) {
+            newUser.setId( session.userId );
+        }
+        return newUser;
+    }
+
+    public boolean function isLoggedIn() {
+        return structKeyExists( session, "userId" ) && session.userId != "";
+    }
+
+    public boolean function login( User user ) {
+        session.userId = arguments.user.getId();
+        request.user = arguments.user;
+        return true;
+    }
+
+    public void function logout() {
+        structDelete( session, "userId" );
+        structDelete( request, "user" );
+    }
+
+}

--- a/tests/specs/integration/ModuleAuthorizationSpec.cfc
+++ b/tests/specs/integration/ModuleAuthorizationSpec.cfc
@@ -15,59 +15,62 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
             it( "redirects the user if the component has a secured annotation with a list of permissions and the user is not logged in", function() {
                 var event = execute( event = "myModule:PermissionSecured.fooPermissionAction" );
-                expect( event.getValue( "event", "" ) ).toBe( "myModule:Main.onAuthenticationFailure" );
+                expect( event.getValue( "relocate_EVENT", "" ) ).toBe( "myModule:Main.onAuthenticationFailure" );
             } );
 
             it( "redirects the user if the component has a secured annotation with a list of permissions and the user does not have any permissions", function() {
                 authenticationService.login( createUser( { permissions = [] } ) );
                 var event = execute( event = "myModule:PermissionSecured.fooPermissionAction" );
-                expect( event.getValue( "event", "" ) ).toBe( "myModule:Main.onAuthorizationFailure" );
+                expect( event.getValue( "relocate_EVENT", "" ) ).toBe( "myModule:Main.onAuthorizationFailure" );
             } );
 
             it( "redirects the user if the component has a secured annotation with a list of permissions and the user does not have any of the required permissions", function() {
                 authenticationService.login( createUser( { permissions = [ "bar" ] } ) );
                 var event = execute( event = "myModule:PermissionSecured.fooPermissionAction" );
-                expect( event.getValue( "event", "" ) ).toBe( "myModule:Main.onAuthorizationFailure" );
+                expect( event.getValue( "relocate_EVENT", "" ) ).toBe( "myModule:Main.onAuthorizationFailure" );
             } );
 
             it( "does not redirect the user if the component has a secured annotation with a list of permissions and the user has at least one of the required permissions", function() {
                 authenticationService.login( createUser( { permissions = [ "foo" ] } ) );
                 var event = execute( event = "myModule:PermissionSecured.fooPermissionAction" );
+                expect( event.valueExists( "relocate_EVENT" ) ).toBeFalse();
                 expect( event.getValue( "event", "" ) ).toBe( "myModule:PermissionSecured.fooPermissionAction" );
             } );
 
             it( "redirects the user if the action has a secured annotation with a list of permissions and the user is not logged in", function() {
                 var event = execute( event = "myModule:PermissionActionSecured.fooPermissionAction" );
-                expect( event.getValue( "event", "" ) ).toBe( "myModule:Main.onAuthenticationFailure" );
+                expect( event.getValue( "relocate_EVENT", "" ) ).toBe( "myModule:Main.onAuthenticationFailure" );
             } );
 
             it( "redirects the user if the action has a secured annotation with a list of permissions and the user does not have any permissions", function() {
                 authenticationService.login( createUser( { permissions = [] } ) );
                 var event = execute( event = "myModule:PermissionActionSecured.fooPermissionAction" );
-                expect( event.getValue( "event", "" ) ).toBe( "myModule:Main.onAuthorizationFailure" );
+                expect( event.getValue( "relocate_EVENT", "" ) ).toBe( "myModule:Main.onAuthorizationFailure" );
             } );
 
             it( "redirects the user if the action has a secured annotation with a list of permissions and the user does not have any of the required permissions", function() {
                 authenticationService.login( createUser( { permissions = [ "bar" ] } ) );
                 var event = execute( event = "myModule:PermissionActionSecured.fooPermissionAction" );
-                expect( event.getValue( "event", "" ) ).toBe( "myModule:Main.onAuthorizationFailure" );
+                expect( event.getValue( "relocate_EVENT", "" ) ).toBe( "myModule:Main.onAuthorizationFailure" );
             } );
 
             it( "does not redirect the user if the action has a secured annotation with a list of permissions and the user has at least one of the required permissions", function() {
                 authenticationService.login( createUser( { permissions = [ "foo" ] } ) );
                 var event = execute( event = "myModule:PermissionActionSecured.fooPermissionAction" );
+                expect( event.valueExists( "relocate_EVENT" ) ).toBeFalse();
                 expect( event.getValue( "event", "" ) ).toBe( "myModule:PermissionActionSecured.fooPermissionAction" );
             } );
 
             it( "redirects the user if the component has a secured annotatoin with a list of permissions and the user has at least one of the required permissions but the action also has a secured annotation with a list of permissions and the user does not have any of the required permissions", function() {
                 authenticationService.login( createUser( { permissions = [ "one" ] } ) );
                 var event = execute( event = "myModule:DoubleSecured.securedAction" );
-                expect( event.getValue( "event", "" ) ).toBe( "myModule:Main.onAuthorizationFailure" );
+                expect( event.getValue( "relocate_EVENT", "" ) ).toBe( "myModule:Main.onAuthorizationFailure" );
             } );
 
             it( "does not redirect the user if the component has a secured annotatoin with a list of permissions and the user has at least one of the required permissions and the action also has a secured annotation with a list of permissions and the user has at least one of the required permissions", function() {
                 authenticationService.login( createUser( { permissions = [ "one", "two" ] } ) );
                 var event = execute( event = "myModule:DoubleSecured.securedAction" );
+                expect( event.valueExists( "relocate_EVENT" ) ).toBeFalse();
                 expect( event.getValue( "event", "" ) ).toBe( "myModule:DoubleSecured.securedAction" );
             } );
         } );

--- a/tests/specs/integration/ModuleAuthorizationSpec.cfc
+++ b/tests/specs/integration/ModuleAuthorizationSpec.cfc
@@ -1,0 +1,97 @@
+component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
+
+    property name="authenticationService" inject="AuthenticationService";
+
+    function beforeAll() {
+        super.beforeAll();
+        getWireBox().autowire( this );
+    }
+
+    function run() {
+        describe( "Authorization Specs", function() {
+            beforeEach( function() {
+                authenticationService.logout();
+            } );
+
+            it( "redirects the user if the component has a secured annotation with a list of permissions and the user is not logged in", function() {
+                var event = execute( event = "myModule:PermissionSecured.fooPermissionAction" );
+                expect( event.getValue( "event", "" ) ).toBe( "myModule:Main.onAuthenticationFailure" );
+            } );
+
+            it( "redirects the user if the component has a secured annotation with a list of permissions and the user does not have any permissions", function() {
+                authenticationService.login( createUser( { permissions = [] } ) );
+                var event = execute( event = "myModule:PermissionSecured.fooPermissionAction" );
+                expect( event.getValue( "event", "" ) ).toBe( "myModule:Main.onAuthorizationFailure" );
+            } );
+
+            it( "redirects the user if the component has a secured annotation with a list of permissions and the user does not have any of the required permissions", function() {
+                authenticationService.login( createUser( { permissions = [ "bar" ] } ) );
+                var event = execute( event = "myModule:PermissionSecured.fooPermissionAction" );
+                expect( event.getValue( "event", "" ) ).toBe( "myModule:Main.onAuthorizationFailure" );
+            } );
+
+            it( "does not redirect the user if the component has a secured annotation with a list of permissions and the user has at least one of the required permissions", function() {
+                authenticationService.login( createUser( { permissions = [ "foo" ] } ) );
+                var event = execute( event = "myModule:PermissionSecured.fooPermissionAction" );
+                expect( event.getValue( "event", "" ) ).toBe( "myModule:PermissionSecured.fooPermissionAction" );
+            } );
+
+            it( "redirects the user if the action has a secured annotation with a list of permissions and the user is not logged in", function() {
+                var event = execute( event = "myModule:PermissionActionSecured.fooPermissionAction" );
+                expect( event.getValue( "event", "" ) ).toBe( "myModule:Main.onAuthenticationFailure" );
+            } );
+
+            it( "redirects the user if the action has a secured annotation with a list of permissions and the user does not have any permissions", function() {
+                authenticationService.login( createUser( { permissions = [] } ) );
+                var event = execute( event = "myModule:PermissionActionSecured.fooPermissionAction" );
+                expect( event.getValue( "event", "" ) ).toBe( "myModule:Main.onAuthorizationFailure" );
+            } );
+
+            it( "redirects the user if the action has a secured annotation with a list of permissions and the user does not have any of the required permissions", function() {
+                authenticationService.login( createUser( { permissions = [ "bar" ] } ) );
+                var event = execute( event = "myModule:PermissionActionSecured.fooPermissionAction" );
+                expect( event.getValue( "event", "" ) ).toBe( "myModule:Main.onAuthorizationFailure" );
+            } );
+
+            it( "does not redirect the user if the action has a secured annotation with a list of permissions and the user has at least one of the required permissions", function() {
+                authenticationService.login( createUser( { permissions = [ "foo" ] } ) );
+                var event = execute( event = "myModule:PermissionActionSecured.fooPermissionAction" );
+                expect( event.getValue( "event", "" ) ).toBe( "myModule:PermissionActionSecured.fooPermissionAction" );
+            } );
+
+            it( "redirects the user if the component has a secured annotatoin with a list of permissions and the user has at least one of the required permissions but the action also has a secured annotation with a list of permissions and the user does not have any of the required permissions", function() {
+                authenticationService.login( createUser( { permissions = [ "one" ] } ) );
+                var event = execute( event = "myModule:DoubleSecured.securedAction" );
+                expect( event.getValue( "event", "" ) ).toBe( "myModule:Main.onAuthorizationFailure" );
+            } );
+
+            it( "does not redirect the user if the component has a secured annotatoin with a list of permissions and the user has at least one of the required permissions and the action also has a secured annotation with a list of permissions and the user has at least one of the required permissions", function() {
+                authenticationService.login( createUser( { permissions = [ "one", "two" ] } ) );
+                var event = execute( event = "myModule:DoubleSecured.securedAction" );
+                expect( event.getValue( "event", "" ) ).toBe( "myModule:DoubleSecured.securedAction" );
+            } );
+        } );
+    }
+
+    private function createUser( overrides = {} ) {
+        var props = {
+            id = 1,
+            email = "johndoe@example.com",
+            username = "johndoe",
+            permissions = []
+        };
+        structAppend( props, overrides, true );
+        return tap( getInstance( "User" ), function( user ) {
+            user.setId( props.id );
+            user.setEmail( props.email );
+            user.setUsername( props.username );
+            user.setPermissions( props.permissions );
+        } );
+    }
+
+    private function tap( variable, callback ) {
+        callback( variable );
+        return variable;
+    }
+
+}


### PR DESCRIPTION
If a module specifies a `cbguard` key in its `settings` struct inside `ModuleConfig`, cbguard will use those as overrides to the base module settings.
```
component {
    this.name = "myModule";

    function configure() {
        settings = {
            "cbguard" = {
                "authenticationService" = "SecurityService@myModule",
                "authenticationOverrideEvent" = "myModule:Main.onAuthenticationFailure",
                "authenticationAjaxOverrideEvent" = "myModule:api.v1.BaseAPIHandler.onAuthenticationFailure",
                "authorizationOverrideEvent" = "myModule:Main.onAuthorizationFailure",
                "authorizationAjaxOverrideEvent" = "myModule:api.v1.BaseAPIHandler.onAuthorizationFailure"
            }
        };
    }
}
```

Closes #6 