### PR TITLE
Use local handler actions if they exists

### DIFF
--- a/interceptors/SecuredEventInterceptor.cfc
+++ b/interceptors/SecuredEventInterceptor.cfc
@@ -168,6 +168,19 @@ component extends="coldbox.system.Interceptor"{
         if ( ! structKeyExists( targetActionMetadata, "secured" ) || targetActionMetadata.secured == false ) {
             return false;
         }
+        //override the coldbox.cfc global events if they exist in the handler. Per docs, they will override for Ajax requests also.
+        var handlerAuthenticationFailure = arrayFilter( handlerMetadata.functions, function( func ) {
+                return func.name == "onAuthenticationFailure";
+            } );
+        if ( !arrayIsEmpty( handlerAuthenticationFailure ) ) {
+            props.authenticationOverrideEvent = "#event.getCurrentHandler()#.onAuthenticationFailure"
+        }
+        var handlerAuthorizationFailure = arrayFilter( handlerMetadata.functions, function( func ) {
+                return func.name == "onAuthorizationFailure";
+            } );
+        if ( !arrayIsEmpty( handlerAuthorizationFailure ) ) {
+            props.authorizationOverrideEvent = "#event.getCurrentHandler()#.onAuthorizationFailure"
+        }
 
         if ( ! invoke( props.authenticationService, props.methodNames[ "isLoggedIn" ] ) ) {
             var eventType = event.isAjax() ? "authenticationAjaxOverrideEvent" : "authenticationOverrideEvent";


### PR DESCRIPTION
So my proposal is that cbguard will check to see if in the handler itself, the relevant failure action that exists will be applied instead of the global overrides in the coldbox.cfc module settings. Giving us the ability to relocate on an individual handler basis. If it doesn't exists, the global overrides will fire.
This works with a simple app from https://github.com/elpete/quick-with-auth
I believe these changes will work but as i just started to look into cbguard, i don't have a complex app to test with.