### PR TITLE
feat(Guard): Add a guard service that can authorize anywhere during the request

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ component secured {
 
 The methods available to you on the `Guard` component are as follows:
 
-```
+```cfc
 public boolean function allows( required any permissions, struct additionalArgs = {} );
 public boolean function denies( required any permissions, struct additionalArgs = {} );
 public boolean function all( required any permissions, struct additionalArgs = {} );
@@ -120,8 +120,43 @@ In all cases `permissions` can be either a string, a list of strings, or an arra
 In the case of `authorize` the `errorMessage` replaces the thrown error message
 in the `NotAuthorized`. exception.  It can also be a closure that takes the following shape:
 
+```cfc
+string function errorMessage( array permissions, any user, struct additionalArgs );
 ```
-string function errorMessage( string failedPermission, any user, struct additionalArgs );
+
+#### Defining Custom Guards
+
+While handling all of your guard clauses inside the `hasPermission` method on your user
+works fine, you may want to define a different way to handle permissions.  You
+can do this by declaring custom guards using the `guard.define` method.  Here's the signature:
+
+```cfc
+public Guard function define( required string name, required any callback );
+```
+
+The `name` will match against a permission name.  If it matches, the guard is
+called instead of calling `hasPermission` on the `User` model. (You can always
+call `hasPermission` on the `User` inside your guard callback if you need.)
+
+The callback can be: a closure or UDF, a component with an `authorize` function,
+or a WireBox mapping to a component with an `authorize` function. Please note
+that the authorize function must be explicitly defined and public (No `onMissingMethod`).
+This `authorize` function is called with two parameters: the `user` being authorized
+and a struct of `additionalArgs` and must return a `boolean`, like so:
+
+```cfc
+public boolean function authorize( required any user, struct additionalArgs = {} );
+```
+
+Using this approach, you can define custom guards anywhere in your application:
+`config/ColdBox.cfc`, `ModuleConfig.cfc` of your custom modules, etc.  The
+`Guard` component is registered as a singleton, so it will keep track of all the
+guards registered, even from different sources.
+
+If you have a need to remove a guard definition you can do so with the `removeDefinition` method:
+
+```cfc
+public Guard function removeDefinition( required string name );
 ```
 
 ### Redirects

--- a/interfaces/HasPermissionInterface.cfc
+++ b/interfaces/HasPermissionInterface.cfc
@@ -2,7 +2,10 @@ interface {
 
     /**
     * Returns true if the user has the specified permission.
+    * Any additional arguments may be passed in as the second argument.
+    * This allows you to check if a user can access a specific resource,
+    * rather than just a generic check.
     */
-    public boolean function hasPermission( required string permission );
+    public boolean function hasPermission( required string permission, struct additionalArgs );
 
 }

--- a/models/Guard.cfc
+++ b/models/Guard.cfc
@@ -1,0 +1,168 @@
+component singleton {
+
+    property name="settings" inject="coldbox:moduleSettings:cbguard";
+    property name="moduleService" inject="coldbox:moduleService";
+    property name="wirebox" inject="wirebox";
+
+    function allows( required any permissions, struct additionalArgs = {}, boolean negate = false ) {
+        var context = preflight();
+
+        for ( var permission in arrayWrap( arguments.permissions ) ) {
+            var hasPermission = invoke(
+                context.user,
+                context.props.methodNames[ "hasPermission" ],
+                {
+                    "permission": permission,
+                    "additionalArgs": arguments.additionalArgs
+                }
+            );
+
+            if ( hasPermission ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    function denies( required any permissions, struct additionalArgs = {} ) {
+        var context = preflight();
+
+        for ( var permission in arrayWrap( arguments.permissions ) ) {
+            var hasPermission = invoke(
+                context.user,
+                context.props.methodNames[ "hasPermission" ],
+                {
+                    "permission": permission,
+                    "additionalArgs": arguments.additionalArgs
+                }
+            );
+
+            if ( !hasPermission ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public boolean function all( required any permissions, struct additionalArgs = {} ) {
+        var context = preflight();
+
+        for ( var permission in arrayWrap( arguments.permissions ) ) {
+            var hasPermission = invoke(
+                context.user,
+                context.props.methodNames[ "hasPermission" ],
+                {
+                    "permission": permission,
+                    "additionalArgs": arguments.additionalArgs
+                }
+            );
+
+            if ( !hasPermission ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public boolean function none( required any permissions, struct additionalArgs = {} ) {
+        var context = preflight();
+
+        for ( var permission in arrayWrap( arguments.permissions ) ) {
+            var hasPermission = invoke(
+                context.user,
+                context.props.methodNames[ "hasPermission" ],
+                {
+                    "permission": permission,
+                    "additionalArgs": arguments.additionalArgs
+                }
+            );
+
+            if ( hasPermission ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public void function authorize(
+        required any permissions,
+        struct additionalArgs = {},
+        string errorMessage
+    ) {
+        var context = preflight();
+
+        var failedPermission = "";
+        for ( var permission in arrayWrap( arguments.permissions ) ) {
+            var hasPermission = invoke(
+                context.user,
+                context.props.methodNames[ "hasPermission" ],
+                {
+                    "permission": permission,
+                    "additionalArgs": arguments.additionalArgs
+                }
+            );
+
+            if ( !hasPermission ) {
+                failedPermission = permission;
+                break;
+            }
+        }
+
+        if ( failedPermission != "" ) {
+            param arguments.errorMessage = "The logged in user is not authorized to access this resource";
+
+            if ( isClosure( arguments.errorMessage ) || isCustomFunction( arguments.errorMessage ) ) {
+                arguments.errorMessage = arguments.errorMessage(
+                    failedPermission = failedPermission,
+                    user = context.user,
+                    additionalArgs = arguments.additionalArgs
+                );
+            }
+
+            throw(
+                type = "NotAuthorized",
+                message = arguments.errorMessage
+            );
+        }
+    }
+
+    private struct function preflight() {
+        var event = variables.wirebox.getInstance( dsl = "coldbox:requestContext" );
+
+        var props = {};
+        structAppend( props, variables.settings, true );
+        if ( event.getCurrentModule() != "" ) {
+            var moduleConfig = variables.moduleService.getModuleConfigCache()[ event.getCurrentModule() ];
+            var moduleSettings = moduleConfig.getPropertyMixin( "settings", "variables", {} );
+            if ( structKeyExists( moduleSettings, "cbguard" ) ) {
+                structAppend( props, moduleSettings.cbguard, true );
+            }
+        }
+
+        if ( isSimpleValue( props.authenticationService ) ) {
+            props.authenticationService = variables.wirebox.getInstance( dsl = props.authenticationService );
+        }
+
+        if ( ! invoke( props.authenticationService, props.methodNames[ "isLoggedIn" ] ) ) {
+            throw(
+                type = "NotLoggedIn",
+                message = "No user is logged in to authorize."
+            )
+        }
+
+        return {
+            "event": event,
+            "props": props,
+            "user": invoke( props.authenticationService, props.methodNames[ "getUser" ] )
+        };
+    }
+
+    private array function arrayWrap( required any items ) {
+        return isArray( arguments.items ) ? items : items.listToArray();
+    }
+
+}

--- a/models/Guard.cfc
+++ b/models/Guard.cfc
@@ -1,23 +1,84 @@
-component singleton {
+component singleton accessors="true" {
 
     property name="settings" inject="coldbox:moduleSettings:cbguard";
     property name="moduleService" inject="coldbox:moduleService";
     property name="wirebox" inject="wirebox";
 
-    function allows( required any permissions, struct additionalArgs = {}, boolean negate = false ) {
+    property name="guards" type="struct";
+
+    /**
+     * Creates a new Guard service
+     *
+     * @returns cbguard.models.Guard
+     */
+    public Guard function init() {
+        variables.guards = {};
+        return this;
+    }
+
+    /**
+     * Defines a new custom guard.  A custom guard is used instead of the
+     * user model's `hasPermission` method.
+     *
+     * @name      The name of the permission to match for this custom guard.
+     * @callback  The callback to resolve the custom guard. It should return a boolean.
+     *            This can be one of the following:
+     *                1. A UDF or closure.
+     *                2. A component with an `authorize` method.
+     *                3. A WireBox mapping that resolves to a component with an `authorize` method.
+     *
+     * @throws    InvalidGuardType
+     *
+     * @returns   cbguard.models.Guard
+     */
+    public Guard function define( required string name, required any callback ) {
+        if ( isSimpleValue( arguments.callback ) ) {
+            arguments.callback = variables.wirebox.getInstance( dsl = callback );
+            if ( !structKeyExists( arguments.callback, "authorize" ) ) {
+                throw(
+                    type = "InvalidGuardType",
+                    message = "A component guard must have an `authorize` method defined."
+                );
+            }
+        } else if ( isClosure( arguments.callback ) || isCustomFunction( arguments.callback ) ) {
+            arguments.callback = { "authorize": arguments.callback };
+        } else {
+            throw(
+                type = "InvalidGuardType",
+                message = "Cannot define a guard without either a component with an `authorize` method, a WireBox mapping to a component with an `authorize` method, or a closure or UDF function."
+            );
+        }
+
+        variables.guards[ arguments.name ] = arguments.callback;
+        return this;
+    }
+
+    /**
+     * Removes a custom guard definition.
+     *
+     * @name     The name of the permission to remove the custom guard.
+     * @returns  cbguard.models.Guard
+     */
+    public Guard function removeDefinition( required string name ) {
+        structDelete( variables.guards, arguments.name );
+        return this;
+    }
+
+
+    /**
+     * Returns true if the logged in user is allowed for any of the permissions.
+     *
+     * @permissions     A single string permission, list of string permissions,
+     *                  or array of string permissions to check.
+     * @additionalArgs  A struct of any additional arguments to pass to the guard.
+     *
+     * @returns         boolean
+     */
+    public boolean function allows( required any permissions, struct additionalArgs = {} ) {
         var context = preflight();
 
         for ( var permission in arrayWrap( arguments.permissions ) ) {
-            var hasPermission = invoke(
-                context.user,
-                context.props.methodNames[ "hasPermission" ],
-                {
-                    "permission": permission,
-                    "additionalArgs": arguments.additionalArgs
-                }
-            );
-
-            if ( hasPermission ) {
+            if ( resolvePermission( permission, context, arguments.additionalArgs ) ) {
                 return true;
             }
         }
@@ -25,20 +86,20 @@ component singleton {
         return false;
     }
 
-    function denies( required any permissions, struct additionalArgs = {} ) {
+    /**
+     * Returns true if the logged in user is not allowed for at least one of the permissions.
+     *
+     * @permissions     A single string permission, list of string permissions,
+     *                  or array of string permissions to check.
+     * @additionalArgs  A struct of any additional arguments to pass to the guard.
+     *
+     * @returns         boolean
+     */
+    public boolean function denies( required any permissions, struct additionalArgs = {} ) {
         var context = preflight();
 
         for ( var permission in arrayWrap( arguments.permissions ) ) {
-            var hasPermission = invoke(
-                context.user,
-                context.props.methodNames[ "hasPermission" ],
-                {
-                    "permission": permission,
-                    "additionalArgs": arguments.additionalArgs
-                }
-            );
-
-            if ( !hasPermission ) {
+            if ( !resolvePermission( permission, context, arguments.additionalArgs ) ) {
                 return true;
             }
         }
@@ -46,20 +107,20 @@ component singleton {
         return false;
     }
 
+    /**
+     * Returns true if the logged in user is allowed for all of the permissions.
+     *
+     * @permissions     A single string permission, list of string permissions,
+     *                  or array of string permissions to check.
+     * @additionalArgs  A struct of any additional arguments to pass to the guard.
+     *
+     * @returns         boolean
+     */
     public boolean function all( required any permissions, struct additionalArgs = {} ) {
         var context = preflight();
 
         for ( var permission in arrayWrap( arguments.permissions ) ) {
-            var hasPermission = invoke(
-                context.user,
-                context.props.methodNames[ "hasPermission" ],
-                {
-                    "permission": permission,
-                    "additionalArgs": arguments.additionalArgs
-                }
-            );
-
-            if ( !hasPermission ) {
+            if ( !resolvePermission( permission, context, arguments.additionalArgs ) ) {
                 return false;
             }
         }
@@ -67,20 +128,20 @@ component singleton {
         return true;
     }
 
+    /**
+     * Returns true if the logged in user is denied for all of the permissions.
+     *
+     * @permissions     A single string permission, list of string permissions,
+     *                  or array of string permissions to check.
+     * @additionalArgs  A struct of any additional arguments to pass to the guard.
+     *
+     * @returns         boolean
+     */
     public boolean function none( required any permissions, struct additionalArgs = {} ) {
         var context = preflight();
 
         for ( var permission in arrayWrap( arguments.permissions ) ) {
-            var hasPermission = invoke(
-                context.user,
-                context.props.methodNames[ "hasPermission" ],
-                {
-                    "permission": permission,
-                    "additionalArgs": arguments.additionalArgs
-                }
-            );
-
-            if ( hasPermission ) {
+            if ( resolvePermission( permission, context, arguments.additionalArgs ) ) {
                 return false;
             }
         }
@@ -88,36 +149,47 @@ component singleton {
         return true;
     }
 
-    public void function authorize(
+    /**
+     * Throws an exception if the logged in user is not allowed for any of the permissions.
+     *
+     * @permissions     A single string permission, list of string permissions,
+     *                  or array of string permissions to check.
+     * @additionalArgs  A struct of any additional arguments to pass to the guard.
+     * @errorMessage    The error message to throw with the exception.
+     *                  It can be either:
+     *                      1. A string error message
+     *                      2. A closure or UDF that will produce a string error
+     *                         message.  This callback receives the following arguments:
+     *                             a. The `permissions` tried.
+     *                             b. The logged in `user`.
+     *                             c. The `additionalArgs` passed.
+     *
+     * @throws          NotAuthorized
+     *
+     * @returns         cbguard.models.Guard
+     */
+    public Guard function authorize(
         required any permissions,
         struct additionalArgs = {},
-        string errorMessage
+        any errorMessage
     ) {
         var context = preflight();
 
-        var failedPermission = "";
-        for ( var permission in arrayWrap( arguments.permissions ) ) {
-            var hasPermission = invoke(
-                context.user,
-                context.props.methodNames[ "hasPermission" ],
-                {
-                    "permission": permission,
-                    "additionalArgs": arguments.additionalArgs
-                }
-            );
-
-            if ( !hasPermission ) {
-                failedPermission = permission;
+        arguments.permissions = arrayWrap( arguments.permissions );
+        var passed = false;
+        for ( var permission in arguments.permissions ) {
+            if ( resolvePermission( permission, context, arguments.additionalArgs ) ) {
+                passed = true;
                 break;
             }
         }
 
-        if ( failedPermission != "" ) {
+        if ( !passed ) {
             param arguments.errorMessage = "The logged in user is not authorized to access this resource";
 
             if ( isClosure( arguments.errorMessage ) || isCustomFunction( arguments.errorMessage ) ) {
                 arguments.errorMessage = arguments.errorMessage(
-                    failedPermission = failedPermission,
+                    permissions = arguments.permissions,
                     user = context.user,
                     additionalArgs = arguments.additionalArgs
                 );
@@ -128,8 +200,19 @@ component singleton {
                 message = arguments.errorMessage
             );
         }
+
+        return this;
     }
 
+    /**
+     * Handles getting the current cbguard context for this guard.
+     * Returns a struct with the current `RequestContext` (`event`), the current
+     * settings for the request (`props`), and the currently logged in user (`user`).
+     *
+     * @throws   NotLoggedIn
+     *
+     * @returns  { "event", "props", "user" }
+     */
     private struct function preflight() {
         var event = variables.wirebox.getInstance( dsl = "coldbox:requestContext" );
 
@@ -161,6 +244,49 @@ component singleton {
         };
     }
 
+    /**
+     * Resolves the permission check.  It first checks and tries any custom guards.
+     * If no custom guards exist, it checks the current user's `hasPermission` method.
+     *
+     * @permission      The permission being checked.
+     * @context         The guard context, including `event`, `props`, and `user`.
+     * @additionalArgs  A struct of any additional arguments to pass to the guard.
+     *
+     * @return          boolean
+     */
+    private boolean function resolvePermission(
+        required string permission,
+        required struct context,
+        struct additionalArgs = {}
+    ) {
+        if ( variables.guards.keyExists( arguments.permission ) ) {
+            return invoke(
+                variables.guards[ arguments.permission ],
+                "authorize",
+                {
+                    "user": arguments.context.user,
+                    "additionalArgs": arguments.additionalArgs
+                }
+            );
+        }
+
+        return invoke(
+            arguments.context.user,
+            arguments.context.props.methodNames[ "hasPermission" ],
+            {
+                "permission": arguments.permission,
+                "additionalArgs": arguments.additionalArgs
+            }
+        );
+    }
+
+    /**
+     * Ensures that the returned value is an array.
+     * Returns a passed array unmodified. Calls `listToArray` on all other values.
+     *
+     * @doc_generic  any
+     * @return       [any]
+     */
     private array function arrayWrap( required any items ) {
         return isArray( arguments.items ) ? items : items.listToArray();
     }

--- a/tests/resources/app/handlers/GuardSpecHandler.cfc
+++ b/tests/resources/app/handlers/GuardSpecHandler.cfc
@@ -1,0 +1,62 @@
+component {
+
+    property name="guard" inject="Guard@cbguard";
+
+    function preHandler( event, rc, prc ) {
+        event.noRender();
+    }
+
+    function notLoggedIn( event, rc, prc ) {
+        guard.allows( "do-something" );
+    }
+
+    function authorizedSinglePermission() {
+        prc.isAllowed = guard.allows( "do-something" );
+    }
+
+    function notAuthorizedSinglePermission() {
+        prc.isAllowed = guard.allows( "do-something" );
+    }
+
+    function deniedSinglePermission() {
+        prc.isDenied = guard.denies( "do-something" );
+    }
+
+    function notDeniedSinglePermission() {
+        prc.isDenied = guard.denies( "do-something" );
+    }
+
+    function authorizedMultiplePermission() {
+        prc.isAllowed = guard.allows( [ "do-something", "do-something-else" ] );
+    }
+
+    function deniedMultiplePermission() {
+        prc.isDenied = guard.denies( [ "do-something", "do-something-else" ] );
+    }
+
+    function allowedAllPermissions() {
+        prc.isAllowed = guard.all( [ "do-something", "do-something-else" ] );
+    }
+
+    function notAllowedAllPermissions() {
+        prc.isAllowed = guard.all( [ "do-something", "do-something-else" ] );
+    }
+
+    function deniedAllPermissions() {
+        prc.isDenied = guard.none( [ "do-something", "do-something-else" ] );
+    }
+
+    function notDeniedAllPermissions() {
+        prc.isDenied = guard.none( [ "do-something", "do-something-else" ] );
+    }
+
+    function authorized() {
+        guard.authorize( "do-something" );
+    }
+
+    function accessPost() {
+        var post = getInstance( "Post" ).setId( 1 );
+        prc.isAllowed = guard.allows( "access-post", { "post": post } );
+    }
+
+}

--- a/tests/resources/app/models/AuthenticationService.cfc
+++ b/tests/resources/app/models/AuthenticationService.cfc
@@ -1,5 +1,7 @@
 component {
 
+    property name="wirebox" inject="wirebox";
+
     public function getUser() {
         if ( structKeyExists( request, "user" ) ) {
             return request.user;

--- a/tests/resources/app/models/CustomGuard.cfc
+++ b/tests/resources/app/models/CustomGuard.cfc
@@ -1,0 +1,7 @@
+component {
+
+    function authorize( required user, struct additionalArgs = {} ) {
+        return arguments.user.getId() == 2;
+    }
+
+}

--- a/tests/resources/app/models/Post.cfc
+++ b/tests/resources/app/models/Post.cfc
@@ -1,0 +1,5 @@
+component accessors="true" {
+
+    property name="id";
+
+}

--- a/tests/resources/app/models/User.cfc
+++ b/tests/resources/app/models/User.cfc
@@ -10,7 +10,10 @@ component accessors="true" {
         return this;
     }
 
-    public boolean function hasPermission( required string permission ) {
+    public boolean function hasPermission( required string permission, struct additionalArgs = {} ) {
+        if ( arguments.permission == "access-post" ) {
+            return arguments.additionalArgs.post.getId() == getId();
+        }
         return arrayContains( getPermissions(), permission );
     }
 

--- a/tests/specs/integration/GuardSpec.cfc
+++ b/tests/specs/integration/GuardSpec.cfc
@@ -99,6 +99,34 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 var event = execute( event = "GuardSpecHandler.accessPost" );
                 expect( event.getPrivateValue( "isAllowed" ) ).toBeFalse();
             } );
+
+            it( "can define a guard that will be fired instead of hasPermission if it exists", function() {
+                var guard = getWireBox().getInstance( "Guard@cbguard" );
+                guard.define( "access-post", function( user, additionalArgs ) {
+                    return user.getId() == 2;
+                } );
+
+                try {
+                    variables.authenticationService.login( createUser( { id = 2, permissions = [] } ) );
+                    var event = execute( event = "GuardSpecHandler.accessPost" );
+                    expect( event.getPrivateValue( "isAllowed" ) ).toBeTrue();
+                } finally {
+                    guard.removeDefinition( "access-post" );
+                }
+            } );
+
+            it( "can define a guard that will be fired instead of hasPermission if it exists using a Wirebox mapping", function() {
+                var guard = getWireBox().getInstance( "Guard@cbguard" );
+                guard.define( "access-post", "CustomGuard" );
+
+                try {
+                    variables.authenticationService.login( createUser( { id = 2, permissions = [] } ) );
+                    var event = execute( event = "GuardSpecHandler.accessPost" );
+                    expect( event.getPrivateValue( "isAllowed" ) ).toBeTrue();
+                } finally {
+                    guard.removeDefinition( "access-post" );
+                }
+            } );
         } );
     }
 

--- a/tests/specs/integration/GuardSpec.cfc
+++ b/tests/specs/integration/GuardSpec.cfc
@@ -1,0 +1,105 @@
+component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
+
+    property name="authenticationService" inject="AuthenticationService";
+
+    function run() {
+        describe( "Guard Specs", function() {
+            beforeEach( function() {
+                variables.authenticationService.logout();
+            } );
+
+            it( "throws an exception if the user is not logged in", function() {
+                expect( function() {
+                    execute( event = "GuardSpecHandler.notLoggedIn" );
+                } ).toThrow( type = "NotLoggedIn" );
+            } );
+
+            it( "returns true if a user is allowed for a permission", function() {
+                variables.authenticationService.login( createUser( { permissions = [ "do-something" ] } ) );
+                var event = execute( event = "GuardSpecHandler.authorizedSinglePermission" );
+                expect( event.getPrivateValue( "isAllowed" ) ).toBeTrue();
+            } );
+
+            it( "returns false if a user is not allowed for a permission", function() {
+                variables.authenticationService.login( createUser( { permissions = [] } ) );
+                var event = execute( event = "GuardSpecHandler.notAuthorizedSinglePermission" );
+                expect( event.getPrivateValue( "isAllowed" ) ).toBeFalse();
+            } );
+
+            it( "returns true if a user is allowed for any of the permissions", function() {
+                variables.authenticationService.login( createUser( { permissions = [ "do-something", "do-something-else" ] } ) );
+                var event = execute( event = "GuardSpecHandler.authorizedMultiplePermission" );
+                expect( event.getPrivateValue( "isAllowed" ) ).toBeTrue();
+            } );
+
+            it( "returns true if a user is denied for a permission", function() {
+                variables.authenticationService.login( createUser( { permissions = [] } ) );
+                var event = execute( event = "GuardSpecHandler.deniedSinglePermission" );
+                expect( event.getPrivateValue( "isDenied" ) ).toBeTrue();
+            } );
+
+            it( "returns false if a user is not denied for a permission", function() {
+                variables.authenticationService.login( createUser( { permissions = [ "do-something" ] } ) );
+                var event = execute( event = "GuardSpecHandler.notDeniedSinglePermission" );
+                expect( event.getPrivateValue( "isDenied" ) ).toBeFalse();
+            } );
+
+            it( "returns true if a user is denied for any of the permissions", function() {
+                variables.authenticationService.login( createUser( { permissions = [ "do-something" ] } ) );
+                var event = execute( event = "GuardSpecHandler.deniedMultiplePermission" );
+                expect( event.getPrivateValue( "isDenied" ) ).toBeTrue();
+            } );
+
+            it( "can check if the user is allowed for all the permissions", function() {
+                variables.authenticationService.login( createUser( { permissions = [ "do-something", "do-something-else" ] } ) );
+                var event = execute( event = "GuardSpecHandler.allowedAllPermissions" );
+                expect( event.getPrivateValue( "isAllowed" ) ).toBeTrue();
+            } );
+
+            it( "can check if the user is not allowed for all the permissions", function() {
+                variables.authenticationService.login( createUser( { permissions = [ "do-something" ] } ) );
+                var event = execute( event = "GuardSpecHandler.notAllowedAllPermissions" );
+                expect( event.getPrivateValue( "isAllowed" ) ).toBeFalse();
+            } );
+
+            it( "can check if the user is allowed for none of the permissions", function() {
+                variables.authenticationService.login( createUser( { permissions = [] } ) );
+                var event = execute( event = "GuardSpecHandler.deniedAllPermissions" );
+                expect( event.getPrivateValue( "isDenied" ) ).toBeTrue();
+            } );
+
+            it( "can check if the user fails the none check", function() {
+                variables.authenticationService.login( createUser( { permissions = [ "do-something" ] } ) );
+                var event = execute( event = "GuardSpecHandler.notDeniedAllPermissions" );
+                expect( event.getPrivateValue( "isDenied" ) ).toBeFalse();
+            } );
+
+            it( "throws an exception if a user is not authorized", function() {
+                variables.authenticationService.login( createUser( { permissions = [] } ) );
+                expect( function() {
+                    var event = execute( event = "GuardSpecHandler.authorized" );
+                } ).toThrow( type = "NotAuthorized" );
+            } );
+
+            it( "does not throw an exception if a user is authorized", function() {
+                variables.authenticationService.login( createUser( { permissions = [ "do-something" ] } ) );
+                expect( function() {
+                    var event = execute( event = "GuardSpecHandler.authorized" );
+                } ).notToThrow( type = "NotAuthorized" );
+            } );
+
+            it( "can pass additional arguments to guard methods", function() {
+                variables.authenticationService.login( createUser( { id = 1, permissions = [] } ) );
+                var event = execute( event = "GuardSpecHandler.accessPost" );
+                expect( event.getPrivateValue( "isAllowed" ) ).toBeTrue();
+            } );
+
+            it( "can pass additional arguments to guard methods and fail", function() {
+                variables.authenticationService.login( createUser( { id = 2, permissions = [] } ) );
+                var event = execute( event = "GuardSpecHandler.accessPost" );
+                expect( event.getPrivateValue( "isAllowed" ) ).toBeFalse();
+            } );
+        } );
+    }
+
+}


### PR DESCRIPTION
The `Guard@cbguard` service can be used anywhere during the request (but
usually in a handler) to authorize a user against a `permission` and an
optional struct of `additionalArgs`.  This does not change any existing
aspects of cbguard.  In the future, a DSL may be introduced that allows
passing `additionalArgs` via the `secured` annotation.